### PR TITLE
Fix JSON structure in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ You can add new slots! This is a bit more involved, as you need to specify more 
         },
         "position" : {
             "$type" : "float3",
-            "value" {
+            "value" : {
                 "x" : 0,
                 "y" : 1.5,
                 "z" : 10


### PR DESCRIPTION
The sample wasn't working properly, and after investigating I found a missing colon.