### PR TITLE
Add empty element

### DIFF
--- a/ResoniteLink/Models/DataModel/EmptyElement.cs
+++ b/ResoniteLink/Models/DataModel/EmptyElement.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json.Serialization;
+
+namespace ResoniteLink
+{
+    public class EmptyElement : Member
+    {
+
+    }
+
+
+    [JsonDerivedType(typeof(EmptyElement), "empty")]
+    public partial class Member { }
+}

--- a/ResoniteLink/REPL_Controller.cs
+++ b/ResoniteLink/REPL_Controller.cs
@@ -432,6 +432,10 @@ namespace ResoniteLink
                         await _messaging.PrintLine(reference.TargetID);
                     break;
 
+                case EmptyElement emptyElement:
+                    await _messaging.PrintLine("<empty element>");
+                    break;
+
                 case SyncList list:
                     await _messaging.PrintLine($"<List (Count: {list.Elements?.Count ?? 0})>");
 


### PR DESCRIPTION
This is for representing data model types that don't contain any data, but are referencable by other elements.