### PR TITLE
Add DateTime & TimeSpan primitives

### DIFF
--- a/ResoniteLink/Models/DataModel/PrimitiveContainers.cs
+++ b/ResoniteLink/Models/DataModel/PrimitiveContainers.cs
@@ -598,6 +598,88 @@ namespace ResoniteLink
 
         
         
+        public class Field_DateTime : Field
+        {
+            [JsonPropertyName("value")]
+            public DateTime Value { get; set; }
+
+            [JsonIgnore]
+            public override object BoxedValue { get => Value; set => Value = (DateTime)value; }
+
+            [JsonIgnore]
+            public override Type ValueType => typeof(DateTime);
+        }
+
+        public class Array_DateTime : SyncArray
+        {
+            [JsonPropertyName("values")]
+            public List<DateTime> Values { get; set; }
+
+            [JsonIgnore]
+            public override Type ElementType => typeof(DateTime);
+        }
+
+        [JsonDerivedType(typeof(Field_DateTime), "DateTime")]
+        [JsonDerivedType(typeof(Array_DateTime), "DateTime[]")]
+        public partial class Member { }
+
+                    public class Field_Nullable_DateTime : Field
+            {
+                [JsonPropertyName("value")]
+                public DateTime? Value { get; set; }
+
+                [JsonIgnore]
+                public override object BoxedValue { get => Value; set => Value = value as DateTime?; }
+
+                [JsonIgnore]
+                public override Type ValueType => typeof(DateTime?);
+            }
+
+            [JsonDerivedType(typeof(Field_Nullable_DateTime), "DateTime?")]
+            public partial class Member { }
+            
+        
+        public class Field_TimeSpan : Field
+        {
+            [JsonPropertyName("value")]
+            public TimeSpan Value { get; set; }
+
+            [JsonIgnore]
+            public override object BoxedValue { get => Value; set => Value = (TimeSpan)value; }
+
+            [JsonIgnore]
+            public override Type ValueType => typeof(TimeSpan);
+        }
+
+        public class Array_TimeSpan : SyncArray
+        {
+            [JsonPropertyName("values")]
+            public List<TimeSpan> Values { get; set; }
+
+            [JsonIgnore]
+            public override Type ElementType => typeof(TimeSpan);
+        }
+
+        [JsonDerivedType(typeof(Field_TimeSpan), "TimeSpan")]
+        [JsonDerivedType(typeof(Array_TimeSpan), "TimeSpan[]")]
+        public partial class Member { }
+
+                    public class Field_Nullable_TimeSpan : Field
+            {
+                [JsonPropertyName("value")]
+                public TimeSpan? Value { get; set; }
+
+                [JsonIgnore]
+                public override object BoxedValue { get => Value; set => Value = value as TimeSpan?; }
+
+                [JsonIgnore]
+                public override Type ValueType => typeof(TimeSpan?);
+            }
+
+            [JsonDerivedType(typeof(Field_Nullable_TimeSpan), "TimeSpan?")]
+            public partial class Member { }
+            
+        
         public class Field_color : Field
         {
             [JsonPropertyName("value")]

--- a/ResoniteLink/Models/DataModel/PrimitiveContainers.tt
+++ b/ResoniteLink/Models/DataModel/PrimitiveContainers.tt
@@ -38,6 +38,9 @@ List<string> standaloneTypes = new List<string>
     "string",
     "Uri",
 
+    "DateTime",
+    "TimeSpan",
+
     "color",
     "colorX",
     "color32",


### PR DESCRIPTION
This adds DateTime & TimeSpan as primitive types since they were previously not supported. 

Note:

System.Text.Json serializes DateTime using ISO 8601-1:2019 https://learn.microsoft.com/en-us/dotnet/standard/datetime/system-text-json-support

TimeSpan is serialized like so: https://learn.microsoft.com/en-us/dotnet/core/compatibility/serialization/6.0/timespan-serialization-format