### PR TITLE
Only build library and not REPL for NuGet

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -41,7 +41,8 @@ jobs:
         if: ${{ env.IS_RELEASE == 'true' }}
         uses: Yellow-Dog-Man/composite-actions-templates/.github/actions/dotnet-build@main
         with:
-          dotnet-build-type: '${{ env.BUILD_TYPE }}'
+          dotnet-project-path: '${{ env.PROJECT_PATH }}'
+          dotnet-build-type: '${{ github.workspace }}/${{ env.BUILD_TYPE }}'
           dotnet-build-args: '-p:Version=${{ github.ref_name }} -o ${{ github.workspace }}/nupkgs'
 
       - name: 'Publish ResoniteLink'


### PR DESCRIPTION
This re-introduces the `'${{ env.PROJECT_PATH }}'` in the publishing path that was lost when moving to templates fully.
