### PR TITLE
Add SessionData with basic metadata of the session

### DIFF
--- a/ResoniteLink/LinkInterface.cs
+++ b/ResoniteLink/LinkInterface.cs
@@ -149,6 +149,8 @@ namespace ResoniteLink
 
         #region API
 
+        public Task<SessionData> GetSessionData() => SendMessage<RequestSessionData, SessionData>(new RequestSessionData());
+
         public Task<SlotData> GetSlotData(GetSlot request) => SendMessage<GetSlot, SlotData>(request);
         public Task<ComponentData> GetComponentData(GetComponent request) => SendMessage<GetComponent, ComponentData>(request);
 

--- a/ResoniteLink/Models/Messages/Message.cs
+++ b/ResoniteLink/Models/Messages/Message.cs
@@ -8,6 +8,8 @@ namespace ResoniteLink
     /// <summary>
     /// Base class for any messages/commands sent to Resonite
     /// </summary>
+    [JsonDerivedType(typeof(RequestSessionData), "requestSessionData")]
+
     [JsonDerivedType(typeof(GetSlot), "getSlot")]
     [JsonDerivedType(typeof(AddSlot), "addSlot")]
     [JsonDerivedType(typeof(UpdateSlot), "updateSlot")]

--- a/ResoniteLink/Models/Messages/RequestSessionData.cs
+++ b/ResoniteLink/Models/Messages/RequestSessionData.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ResoniteLink
+{
+    /// <summary>
+    /// Requests session data of the current ResoniteLink session.
+    /// This will make Resonite send back SessionData response.
+    /// </summary>
+    public class RequestSessionData : Message
+    {
+
+    }
+}

--- a/ResoniteLink/Models/Responses/Response.cs
+++ b/ResoniteLink/Models/Responses/Response.cs
@@ -13,6 +13,7 @@ namespace ResoniteLink
     [JsonDerivedType(typeof(SlotData), "slotData")]
     [JsonDerivedType(typeof(ComponentData), "componentData")]
     [JsonDerivedType(typeof(AssetData), "assetData")]
+    [JsonDerivedType(typeof(SessionData), "sessionData")]
     public class Response
     {
         /// <summary>

--- a/ResoniteLink/Models/Responses/SessionData.cs
+++ b/ResoniteLink/Models/Responses/SessionData.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json.Serialization;
+
+namespace ResoniteLink
+{
+    public class SessionData : Response
+    {
+        /// <summary>
+        /// Version number of Resonite
+        /// </summary>
+        [JsonPropertyName("resoniteVersion")]
+        public string ResoniteVersion { get; set; }
+
+        /// <summary>
+        /// Version number of ResoniteLink library that Resonite uses
+        /// </summary>
+        [JsonPropertyName("resoniteLinkVersion")]
+        public string ResoniteLinkVersion { get; set; }
+
+        /// <summary>
+        /// An ID uniquely identifying this ResoniteLink session for a given Resonite session
+        /// The ID is unique for as long as particular session runs on Resonite's end
+        /// The ID is NOT guaranteed to be unique for different Resonite worlds with ResoniteLink enabled
+        /// The ID is NOT guaranteed to be unique when the Resonite world restarts
+        /// You can use this ID to ensure that any ID's you generate do not conflict with any other
+        /// ResoniteLink session for a given Resonite world.
+        /// </summary>
+        [JsonPropertyName("uniqueSessionId")]
+        public string UniqueSessionId { get; set; }
+    }
+}

--- a/ResoniteLink/REPL_Controller.cs
+++ b/ResoniteLink/REPL_Controller.cs
@@ -26,20 +26,21 @@ namespace ResoniteLink
             _link = link;
             _messaging = messaging;
 
-            if (prefix == null)
-            {
-                // If none is provided, just generate one at random
-                // This isn't the most robust, as it can collide, but usually there's only a handful sessions at most
-                // so this should work well enough for these purposes
-                var r = new Random();
-                _prefix = r.Next().ToString("X");
-            }
-            else
-                _prefix = prefix;
+            _prefix = prefix;
         }
 
         public async Task RunLoop()
         {
+            var sessionData = await _link.GetSessionData();
+
+            // Use the unique session ID when prefix is not specified
+            if (string.IsNullOrEmpty(_prefix))
+                _prefix = sessionData.UniqueSessionId;
+
+            await _messaging.PrintLine($"Resonite version: {sessionData.ResoniteVersion}\n" +
+                $"ResoniteLink version: {sessionData.ResoniteLinkVersion}\n" +
+                $"Session ID: {sessionData.UniqueSessionId}");
+
             // Make sure we start with the root slot selected
             if (CurrentSlot == null)
                 await SelectSlot(Slot.ROOT_SLOT_ID);


### PR DESCRIPTION
This adds ability to fetch basic metadata of the current session (mostly versions of Resonite & ResoniteLink) and a unique session ID which can be used to avoid ID conflicts. 

Closes https://github.com/Yellow-Dog-Man/ResoniteLink/issues/39