### PR TITLE
Added thread safe message sending to LinkInterface.

### DIFF
--- a/ResoniteLink/Utility/SemaphoreLock.cs
+++ b/ResoniteLink/Utility/SemaphoreLock.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ResoniteLink
+{
+    /// <summary>
+    /// A lock around a semaphore that when disposed, releases the lock count.
+    ///
+    /// This value is not designed to be passed around.
+    /// </summary>
+    /// <example>
+    ///  using(await SemaphoreLock.AcquireAsync(sem, cancellationToken))
+    ///  {
+    ///    // sensitive operations
+    ///  }
+    /// </example>
+    internal struct SemaphoreLock : IDisposable
+    {
+        private readonly SemaphoreSlim _sem;
+        private bool _disposed;
+        private SemaphoreLock(SemaphoreSlim sem)
+        {
+            _sem = sem;
+            _disposed = false;
+        }
+        
+        public static async ValueTask<SemaphoreLock> AcquireAsync(SemaphoreSlim sem, CancellationToken cancellationToken)
+        {
+            await sem.WaitAsync(cancellationToken);
+            return new SemaphoreLock(sem);
+        }
+        
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                _disposed = true;
+                _sem?.Release();
+            }
+        }
+    }
+}


### PR DESCRIPTION
# The change

The change should allow this code to execute safely:
```
LinkInterface link;
for (int i = 0; i < 100; i++)
{
  Task.Run(link.GetSessionData);
}
```

Previously you could only send messages synchronously safely. Each call to SendAsync would block until the paired message got back, but I do not believe SendAsync guarantees each send is internally thread safe (ignoring sending binary blobs, two possibly interleaveable calls).

# Alternatives

Another alternative is swapping to `Task<Task<O>> SendMessage<I,O>`, the outer task resolves when the message is sent, the inner when the response is received. That would be a breaking change though. Instead messages can now be sent concurrently.

# Testing

I tested this with the repl, and it appeared to work. At the very least the race conditions are probably less present.

# Notes

I also added a very dumb wrapper where a semaphore can acquire or release automatically. This is possibly not totally safe, but hopefully safe enough.

I just noticed the formatter did end up running over the code, I tried to undo those, but it looks like the editor ran it anyways on commit. If requested I can undo those formatting changes.
