### PR TITLE
Add new round of community projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ There are a few community projects built around or with ResoniteLink:
 
 ## Rust <img alt="Rust programming language logo. R letter in a dented wheel." src="https://skillicons.dev/icons?i=rust" width="16">
 
-| Repository                                                                      | Description                                                                                       |
-|---------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
+| Repository                                                  | Description                            |
+|-------------------------------------------------------------|----------------------------------------|
+| [Resoxide/resoxide-link](github.com/Resoxide/resoxide-link) | A Rust implementation of ResoniteLink. |
 
 ## Golang  <img alt="Golang programming language logo. Go text on coloured background." src="https://skillicons.dev/icons?i=go" width="16">
 


### PR DESCRIPTION
This PR adds a new round of community projects built for, or around, ResoniteLink to the README.

It also removes one project that has been marked as abandoned as per author (#75).

Closes #42 #58 #75 #87