### PR TITLE
Add NewEntityId response for adding slots/components

### DIFF
--- a/ResoniteLink/LinkInterface.cs
+++ b/ResoniteLink/LinkInterface.cs
@@ -153,11 +153,11 @@ namespace ResoniteLink
         public Task<SlotData> GetSlotData(GetSlot request) => SendMessage<GetSlot, SlotData>(request);
         public Task<ComponentData> GetComponentData(GetComponent request) => SendMessage<GetComponent, ComponentData>(request);
 
-        public Task<Response> AddSlot(AddSlot request) => SendMessage<AddSlot, Response>(request);
+        public Task<NewEntityId> AddSlot(AddSlot request) => SendMessage<AddSlot, NewEntityId>(request);
         public Task<Response> UpdateSlot(UpdateSlot request) => SendMessage<UpdateSlot, Response>(request);
         public Task<Response> RemoveSlot(RemoveSlot request) => SendMessage<RemoveSlot, Response>(request);
 
-        public Task<Response> AddComponent(AddComponent request) => SendMessage<AddComponent, Response>(request);
+        public Task<NewEntityId> AddComponent(AddComponent request) => SendMessage<AddComponent, NewEntityId>(request);
         public Task<Response> UpdateComponent(UpdateComponent request) => SendMessage<UpdateComponent, Response>(request);
         public Task<Response> RemoveComponent(RemoveComponent request) => SendMessage<RemoveComponent, Response>(request);
 

--- a/ResoniteLink/Models/Responses/NewEntityId.cs
+++ b/ResoniteLink/Models/Responses/NewEntityId.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json.Serialization;
+
+namespace ResoniteLink
+{
+    public class NewEntityId : Response
+    {
+        /// <summary>
+        /// ID of the newly created entity. This can be useful if you're letting Resonite allocate the ID
+        /// You can then use this to fetch the created entity back.
+        /// </summary>
+        [JsonPropertyName("entityId")]
+        public string EntityId { get; set; }
+    }
+}

--- a/ResoniteLink/Models/Responses/Response.cs
+++ b/ResoniteLink/Models/Responses/Response.cs
@@ -10,6 +10,7 @@ namespace ResoniteLink
     /// or contain response data when requested.
     /// </summary>
     [JsonDerivedType(typeof(Response), "response")]
+    [JsonDerivedType(typeof(NewEntityId), "newEntityId")]
     [JsonDerivedType(typeof(SlotData), "slotData")]
     [JsonDerivedType(typeof(ComponentData), "componentData")]
     [JsonDerivedType(typeof(AssetData), "assetData")]


### PR DESCRIPTION
This should address this request: https://github.com/Yellow-Dog-Man/ResoniteLink/issues/33

It adds a field that provides the ID of the newly created entity. This is low overhead and allows for back & forth API's that don't want to specify the ID's themselves and fetch the newly created entities back.