### PR TITLE
Add method to import cubemap from a single file by specifying regions

### DIFF
--- a/ResoniteLink/LinkInterface.cs
+++ b/ResoniteLink/LinkInterface.cs
@@ -165,7 +165,8 @@ namespace ResoniteLink
         public Task<AssetData> ImportTexture(ImportTexture2DRawData request) => SendMessage<ImportTexture2DRawData, AssetData>(request);
         public Task<AssetData> ImportTexture(ImportTexture2DRawDataHDR request) => SendMessage<ImportTexture2DRawDataHDR, AssetData>(request);
 
-        public Task<AssetData> ImportCubemap(ImportCubemapFile request) => SendMessage<ImportCubemapFile, AssetData>(request);
+        public Task<AssetData> ImportCubemap(ImportCubemapFiles request) => SendMessage<ImportCubemapFiles, AssetData>(request);
+        public Task<AssetData> ImportCubemap(ImportCubemapFileWithRegions request) => SendMessage<ImportCubemapFileWithRegions, AssetData>(request);
         public Task<AssetData> ImportCubemap(ImportCubemapRawData request) => SendMessage<ImportCubemapRawData, AssetData>(request);
         public Task<AssetData> ImportCubemap(ImportCubemapRawDataHDR request) => SendMessage<ImportCubemapRawDataHDR, AssetData>(request);
 

--- a/ResoniteLink/Models/Assets/Cubemap/ImportCubemapFileWithRegions.cs
+++ b/ResoniteLink/Models/Assets/Cubemap/ImportCubemapFileWithRegions.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json.Serialization;
+
+namespace ResoniteLink
+{
+    /// <summary>
+    /// Import cubemap asset from a local file system from a single image file with regions specifying location of each face.
+    /// Note that the image file needs to be supported by Resonite, otherwise this will fail.
+    /// If you are unsure if the file format is supported, send raw texture data instead.
+    /// The regions are in normalized coordinates from 0...1 range and will be calculated to actual pixel locations.
+    /// </summary>
+    public class ImportCubemapFileWithRegions : Message
+    {
+        /// <summary>
+        /// Path to a texture file representing the cubemap
+        /// </summary>
+        [JsonPropertyName("filePath")]
+        public string FilePath { get; set; }
+
+        /// <summary>
+        /// Normalized region of the image file representing positive X face
+        /// </summary>
+        [JsonPropertyName("positiveXregion")]
+        public Rect PositiveXRegion { get; set; }
+
+        /// <summary>
+        /// Normalized region of the image file representing positive Y face
+        /// </summary>
+        [JsonPropertyName("positiveYregion")]
+        public Rect PositiveYRegion { get; set; }
+
+        /// <summary>
+        /// Normalized region of the image file representing positive Z face
+        /// </summary>
+        [JsonPropertyName("positiveZregion")]
+        public Rect PositiveZRegion { get; set; }
+
+        /// <summary>
+        /// Normalized region of the image file representing negative X face
+        /// </summary>
+        [JsonPropertyName("negativeXregion")]
+        public Rect NegativeXRegion { get; set; }
+
+        /// <summary>
+        /// Normalized region of the image file representing negative Y face
+        /// </summary>
+        [JsonPropertyName("negativeYregion")]
+        public Rect NegativeYRegion { get; set; }
+
+        /// <summary>
+        /// Normalized region of the image file representing negative Z face
+        /// </summary>
+        [JsonPropertyName("negativeZregion")]
+        public Rect NegativeZRegion { get; set; }
+    }
+}

--- a/ResoniteLink/Models/Assets/Cubemap/ImportCubemapFiles.cs
+++ b/ResoniteLink/Models/Assets/Cubemap/ImportCubemapFiles.cs
@@ -12,7 +12,7 @@ namespace ResoniteLink
     /// Ideally all files should also be same format and size. Otherwise they will be resized
     /// to match the largest dimensions, which can lower the quality.
     /// </summary>
-    public class ImportCubemapFile : Message
+    public class ImportCubemapFiles : Message
     {
         /// <summary>
         /// Path to a texture file representing positive X axis face

--- a/ResoniteLink/Models/Messages/Message.cs
+++ b/ResoniteLink/Models/Messages/Message.cs
@@ -26,7 +26,8 @@ namespace ResoniteLink
     [JsonDerivedType(typeof(ImportTexture2DRawData), "importTexture2DRawData")]
     [JsonDerivedType(typeof(ImportTexture2DRawDataHDR), "importTexture2DRawDataHDR")]
 
-    [JsonDerivedType(typeof(ImportCubemapFile), "importCubemapFile")]
+    [JsonDerivedType(typeof(ImportCubemapFiles), "importCubemapFiles")]
+    [JsonDerivedType(typeof(ImportCubemapFileWithRegions), "importCubemapFileWithRegions")]
     [JsonDerivedType(typeof(ImportCubemapRawData), "importCubemapRawData")]
     [JsonDerivedType(typeof(ImportCubemapRawDataHDR), "importCubemapRawDataHDR")]
 


### PR DESCRIPTION
This adds another method that uses a single file. This is to help match how cubemaps are stored in Unity for ReflectionProbe.