### PR TITLE
Add support for specifying mipmap data for cubemaps

### DIFF
--- a/ResoniteLink/Models/Assets/Cubemap/ImportCubemapRawDataBase.cs
+++ b/ResoniteLink/Models/Assets/Cubemap/ImportCubemapRawDataBase.cs
@@ -16,40 +16,72 @@ namespace ResoniteLink
         public int Size { get; set; }
 
         /// <summary>
+        /// Whether mipmap data is included or not.
+        /// </summary>
+        [JsonPropertyName("mipMaps")]
+        public bool MipMaps { get; set; }
+
+        /// <summary>
+        /// Indicates number of mipmaps this cubemap will have based on its current Size
+        /// </summary>
+        [JsonIgnore]
+        public int MipMapCount
+        {
+            get
+            {
+                // If mipmaps are disabled, it's just the top one
+                if (!MipMaps)
+                    return 1;
+
+                int count = 1;
+                int size = Size;
+
+                while(size > 1)
+                {
+                    count++;
+                    size >>= 1;
+                }
+
+                return count;
+            }
+        }
+
+
+        /// <summary>
         /// Access the raw data of the cubemap positive X face.
         /// </summary>
         /// <returns>2D Span allowing access to individual pixels of the face</returns>
-        public Span2D<C> AccessPositiveX() => AccessFaceRawData(0);
+        public Span2D<C> AccessPositiveX(int mipLevel = 0) => AccessFaceRawData(0, mipLevel);
 
         /// <summary>
         /// Access the raw data of the cubemap positive Y face.
         /// </summary>
         /// <returns>2D Span allowing access to individual pixels of the face</returns>
-        public Span2D<C> AccessPositiveY() => AccessFaceRawData(1);
+        public Span2D<C> AccessPositiveY(int mipLevel = 0) => AccessFaceRawData(1, mipLevel);
 
         /// <summary>
         /// Access the raw data of the cubemap positive Z face.
         /// </summary>
         /// <returns>2D Span allowing access to individual pixels of the face</returns>
-        public Span2D<C> AccessPositiveZ() => AccessFaceRawData(2);
+        public Span2D<C> AccessPositiveZ(int mipLevel = 0) => AccessFaceRawData(2, mipLevel);
 
         /// <summary>
         /// Access the raw data of the cubemap negative X face.
         /// </summary>
         /// <returns>2D Span allowing access to individual pixels of the face</returns>
-        public Span2D<C> AccessNegativeX() => AccessFaceRawData(3);
+        public Span2D<C> AccessNegativeX(int mipLevel = 0) => AccessFaceRawData(3, mipLevel);
 
         /// <summary>
         /// Access the raw data of the cubemap negative Y face.
         /// </summary>
         /// <returns>2D Span allowing access to individual pixels of the face</returns>
-        public Span2D<C> AccessNegativeY() => AccessFaceRawData(4);
+        public Span2D<C> AccessNegativeY(int mipLevel = 0) => AccessFaceRawData(4, mipLevel);
 
         /// <summary>
         /// Access the raw data of the cubemap negative Z face.
         /// </summary>
         /// <returns>2D Span allowing access to individual pixels of the face</returns>
-        public Span2D<C> AccessNegativeZ() => AccessFaceRawData(5);
+        public Span2D<C> AccessNegativeZ(int mipLevel = 0) => AccessFaceRawData(5, mipLevel);
 
         /// <summary>
         /// Access the raw data of the cubemap face as span. You MUST specify Size first.
@@ -57,7 +89,7 @@ namespace ResoniteLink
         /// <returns>2D Span allowing access to individual pixels of the cubemap face data</returns>
         /// <exception cref="ArgumentOutOfRangeException">When size is invalid or not set</exception>
         /// <exception cref="InvalidOperationException">When size changes after already accessing data.</exception>
-        public unsafe Span2D<C> AccessFaceRawData(int faceIndex)
+        public unsafe Span2D<C> AccessFaceRawData(int faceIndex, int mipLevel = 0)
         {
             if (Size <= 0)
                 throw new ArgumentOutOfRangeException(nameof(Size));
@@ -65,16 +97,48 @@ namespace ResoniteLink
             if (faceIndex < 0 || faceIndex >= 6)
                 throw new ArgumentOutOfRangeException(nameof(faceIndex));
 
-            var elements = Size * Size;
-            var faceBytes = sizeof(C) * elements;
-            var totalBytes = faceBytes * 6;
+            // Cache it
+            var mipMapCount = MipMapCount;
+
+            if (mipLevel < 0 || mipLevel >= mipMapCount)
+                throw new ArgumentOutOfRangeException(nameof(mipLevel));
+
+            int accessOffset = 0;
+            int accessSize = Size;
+            int accessFaceBytes = 0;
+
+            int totalBytes = 0;
+
+            int size = Size;
+
+            for(int mip = 0; mip < mipMapCount; mip++)
+            {
+                var mipElements = size * size;
+                var faceBytes = sizeof(C) * mipElements;
+
+                if (mip == mipLevel)
+                {
+                    accessSize = size;
+                    accessFaceBytes = faceBytes;
+                }
+
+                int mipTotalBytes = faceBytes * 6;
+
+                if (mip < mipLevel)
+                    accessOffset += mipTotalBytes;
+
+                totalBytes += mipTotalBytes;
+
+                size >>= 1;
+            }
 
             if (RawBinaryPayload == null)
                 RawBinaryPayload = new byte[totalBytes];
             else if (RawBinaryPayload.Length != totalBytes)
                 throw new InvalidOperationException("Size was changed after data was already accessed. This is not supported");
 
-            return new Span2D<C>(Size, Size, MemoryMarshal.Cast<byte, C>(RawBinaryPayload.AsSpan(faceBytes * faceIndex)));
+            return new Span2D<C>(accessSize, accessSize, MemoryMarshal.Cast<byte, C>(
+                RawBinaryPayload.AsSpan(accessOffset + accessFaceBytes * faceIndex)));
         }
     }
 }


### PR DESCRIPTION
Cubemaps often use special data in their mipmaps. E.g. when they're used for reflection probes, the mipmaps are actually specifically convolved data to represent rough specular reflections.

This adds support to specifying those when sending them over through the raw data.