### PR TITLE
fix(docs): broken resoxide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ There are a few community projects built around or with ResoniteLink:
 
 | Repository                                                  | Description                            |
 |-------------------------------------------------------------|----------------------------------------|
-| [Resoxide/resoxide-link](github.com/Resoxide/resoxide-link) | A Rust implementation of ResoniteLink. |
+| [Resoxide/resoxide-link](https://github.com/Resoxide/resoxide-link) | A Rust implementation of ResoniteLink. |
 
 ## Golang  <img alt="Golang programming language logo. Go text on coloured background." src="https://skillicons.dev/icons?i=go" width="16">
 


### PR DESCRIPTION
The resoxide link did not have the 'https' signifier and thus did not link to the proper repository.