### PR TITLE
Change member definition type to a type reference

### DIFF
--- a/ResoniteLink/Models/Reflection/Members/MemberDefinition.cs
+++ b/ResoniteLink/Models/Reflection/Members/MemberDefinition.cs
@@ -19,6 +19,6 @@ namespace ResoniteLink
         /// The full type is however useful when matching up members for references.
         /// </summary>
         [JsonPropertyName("type")]
-        public string Type { get; set; }
+        public TypeReference Type { get; set; }
     }
 }


### PR DESCRIPTION
This will allow it to be properly resolved and handled, which could be difficult to do otherwise (e.g. with generics).