### PR TITLE
Fix redundant type fields

### DIFF
--- a/ResoniteLink/Models/Reflection/Members/EmptyMemberDefinition.cs
+++ b/ResoniteLink/Models/Reflection/Members/EmptyMemberDefinition.cs
@@ -11,11 +11,6 @@ namespace ResoniteLink
     /// </summary>
     public class EmptyMemberDefinition : MemberDefinition
     {
-        /// <summary>
-        /// The full type of this empty member.
-        /// This can be used to differentiate the different types from each other.
-        /// </summary>
-        [JsonPropertyName("memberType")]
-        public TypeReference MemberType { get; set; }
+        // Nothing needed here. MemberDefinition already contains the type of this member
     }
 }

--- a/ResoniteLink/Models/Reflection/Members/SyncObjectMemberDefinition.cs
+++ b/ResoniteLink/Models/Reflection/Members/SyncObjectMemberDefinition.cs
@@ -11,10 +11,6 @@ namespace ResoniteLink
     /// </summary>
     public class SyncObjectMemberDefinition : MemberDefinition
     {
-        /// <summary>
-        /// Datatype of the sync object
-        /// </summary>
-        [JsonPropertyName("type")]
-        public TypeReference Type { get; set; }
+        // Nothing needed here specifically. MemberDefinition already contains the Type, which is the type of the sync object
     }
 }


### PR DESCRIPTION
With the recent change, these fields are now redundant and can be removed, since they're handled by the base MemberDefinition